### PR TITLE
fix(lists): no longer breaks lists in admin context

### DIFF
--- a/start.php
+++ b/start.php
@@ -33,6 +33,10 @@ elgg_register_event_handler('init', 'system', 'hypelists_init');
  * @return void
  */
 function hypelists_init() {
+        if (elgg_in_context("admin")) {
+              return;
+        }
+
 	$defaults = array(
 		'page/components/list',
 		'page/components/gallery',


### PR DESCRIPTION
This provides a fix for not be able to drag and drop plugins in Admin panel