### PR TITLE
fix(invited): allow listing 'secret' groups for accept/decline an invitation

### DIFF
--- a/classes/hypeJunction/Lists/EntityList.php
+++ b/classes/hypeJunction/Lists/EntityList.php
@@ -492,7 +492,14 @@ abstract class EntityList {
 		$options['base_url'] = $this->getBaseURL();
 		$options['list_id'] = $this->getId();
 
+		if ($type == 'group' && $options['rel'] == 'invited') {
+			$ia = elgg_set_ignore_access(true);
+		}
+
 		$list = elgg_list_entities($options, $this->getter);
+
+		if (isset($ia)) elgg_set_ignore_access($ia);		
+
 		$list = elgg_format_element('div', [
 			'class' => 'elgg-sortable-list-view',
 		], $list);


### PR DESCRIPTION
Like the 'groups_get_invited_groups' function from the 'groups' plugin, when groups invitations are shown require full access, specially for groups whose you cannot see.

But I cannot solved this problem completely...
- when I access to http://mysite.com/groups/invitations works properly, but...
- when I access selecting the option 'Invitations' in the selector the Ajax call works different (bad)